### PR TITLE
update git submodule to use a public HTTPS URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "snowball"]
     path = snowball
-    url = git@github.com:snowballstem/snowball.git
+    url = https://github.com/snowballstem/snowball.git
     branch = master


### PR DESCRIPTION
This Git repo uses the snowball submodule URL of `git@github.com:snowballstem/snowball.git`. GitHub (reasonably) doesn't allow unauthenticated clones through SSH even for public repos, thus fetching submodules for `fts5-snowball` fails even if cloning through HTTPS since the submodule triggers an SSH clone.

Since both repos are public, this shouldn't have any impact other than allowing full unauthenticated clones through HTTPS.