### PR TITLE
Fixed crash when working with multiple databases

### DIFF
--- a/src/fts5stemmer.c
+++ b/src/fts5stemmer.c
@@ -64,6 +64,12 @@ static void destroySnowball(void *p) {
 		sqlite3_free(availableStemmers[i].language);
 	}
 	if (availableStemmers) sqlite3_free(availableStemmers);
+
+    /// Setting `availableStemmers` explicitly to NULL fixes crashes cased by `sqlite3_realloc` called on  `availableStemmers` later on
+    availableStemmers = NULL;
+
+    /// Stemmers were removed so this should be set to 0
+    numberAvailableStemmers = 0;
 }
 
 static int isValidLanguage(char *name) {


### PR DESCRIPTION
Hello!

I use this inside an iOS app, and I found a memory issue when running tests on multiple different databases during tests.
The issue is with how variables are deallocated in `destroySnowball` method.

Two issues:
1, It removes `availableStemmers` from memory, but `numberAvailableStemmers` is not set to 0.
2, Calling `sqlite3_free(availableStemmers)`, doesn't seem to set `availableStemmers` to NULL and next time `sqlite3_realloc` is called with `availableStemmers` it causes crash.

The changes seem to fix the issues, and it's not crashing for me anymore. Do you see any other possible issues this could cause?
Thanks