### PR TITLE
Support for sqlite < 3.20.0 + fix app crash when no fts5 or wrong language

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Those are the main differences. The data can be queried in the same fashion as a
 
 This needs GNU make in order to build. If you're using BSD or similar, you can always get gmake.
 
-Current version requires SQLite 3.20.0 or newer.
+Current version requires SQLite 3.9.0 or newer.
 
 Because snowball is a build dependency, please clone this repo with:
 ```

--- a/src/fts5stemmer.c
+++ b/src/fts5stemmer.c
@@ -213,7 +213,8 @@ static int ftsSnowballCreate(
 
 	if (rc != SQLITE_OK) {
 		ftsSnowballDelete((Fts5Tokenizer*) result);
-		if (stemmers != NULL) sqlite3_free(stemmers);
+		// ftsSnowballDelete() normally releases "stemmers", because result->stemmers = stemmers
+		if (!result && stemmers != NULL) sqlite3_free(stemmers);
 		result = 0;
 	}
 

--- a/src/fts5stemmer.c
+++ b/src/fts5stemmer.c
@@ -285,7 +285,13 @@ int sqlite3_extension_init(sqlite3 *db, char **error, const sqlite3_api_routines
 	languagesList = sb_stemmer_list();
 
 	ftsApi = fts5_api_from_db(db);
-	ftsApi->xCreateTokenizer(ftsApi, "snowball", (void *) ftsApi, &tokenizer, destroySnowball);
-
-	return SQLITE_OK;
+	
+	if (ftsApi) {
+		ftsApi->xCreateTokenizer(ftsApi, "snowball", (void *) ftsApi, &tokenizer, destroySnowball);
+		return SQLITE_OK;
+	} else {
+		*error = sqlite3_mprintf("Can't find fts5 extension");
+		return SQLITE_ERROR;
+	}
 }
+


### PR DESCRIPTION
Hello! Thank you for this library! I use it in my python application to handle non-english texts.

This PR adds some features:
* support for sqlite < 3.20.0 (I was surprised that ubuntu 16.04 has an older version of sqlite on my vds)
* fix app crash when no fts5
* fix app crash when trying to use an unknown language in snowball.
For example CREATE VIRTUAL TABLE t USING fts5(text, tokenize='snowball bad-language') - this produced app crash due to  double free.



